### PR TITLE
Update .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,4 +3,7 @@
   "line-length": false,
   "no-alt-text": false,
   "fenced-code-language": false
+  "MD033": {
+    "allowed_elements": [ "details", "summary", "h1", "h3", "HR", "p", "b", "br", "ol", "ul", "li", "a" ]
+  }
 }


### PR DESCRIPTION
to remove html errors from markdown lint. these elements are used for a collapsable menu in getting started > credentials