### PR TITLE
Removed anchor, added link to eks

### DIFF
--- a/docs/getting-started/external-cluster/eks/eks.md
+++ b/docs/getting-started/external-cluster/eks/eks.md
@@ -6,7 +6,7 @@ description: Learn how to connect your EKS cluster to CAST AI and start optimizi
 
 ## Connect cluster
 
-To connect your EKS cluster, log into the CAST AI console and navigate to the `Connect cluster` window. Copy the following script
+To connect your EKS cluster, [login to the CAST AI console](https://console.cast.ai/external-clusters/new) and navigate to the `Connect cluster` window. Copy the following script
 and run it in your terminal or cloud shell. Make sure that kubectl is installed and can access your cluster.
 
 ![img.png](../../screenshots/connect-cluster-2.png)
@@ -62,3 +62,5 @@ All the `Write` permissions are scoped to a single EKS cluster - it won't have a
 That’s it! Your cluster is onboarded. You can now enable [policies](https://docs.cast.ai/console-overview/policies/) to keep your cluster configuration optimal.
 
 To complete the steps mentioned above manually (without our script), be aware that when you create an Amazon EKS cluster, the IAM entity user or role (such as a federated user that creates the cluster) is automatically granted a `system:masters` permissions in the cluster's RBAC configuration in the control plane. To grant additional AWS users or roles the ability to interact with your cluster, you need to edit the `aws-auth` ConfigMap within Kubernetes. For more information, see [Managing users or IAM roles for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html).
+
+[Connect your cluster here](https://console.cast.ai/external-clusters/new)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,8 +22,6 @@ markdown_extensions:
   - def_list
   - footnotes
   - meta
-  - toc:
-      permalink: true
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:


### PR DESCRIPTION
- Removed anchor permalink TOC extension due to SERP not ranking correctly with the symbol that mkdocs generate (marketing)
- Added hyper link to eks article, that links to connect a cluster. Flow completion