### PR TITLE
Added time to connect and Out-dated agent troubleshooting

### DIFF
--- a/docs/getting-started/external-cluster/overview.md
+++ b/docs/getting-started/external-cluster/overview.md
@@ -4,17 +4,16 @@ description: Explore how external cluster management brings CAST AI features to 
 
 # External Cluster Overview
 
-External cluster management brings CAST AI features, like autoscaler, to externally managed clusters EKS, GKE
-or AKS. By installing [CAST AI agent](https://github.com/castai/k8s-agent), you start observing cluster running costs and potential savings; you can then
-enable features that optimize your cluster - like adding and removing nodes, or right-sizing deployments.
+External cluster management brings CAST AI features like autoscaler to externally-managed clusters on EKS, GKE
+or AKS. By installing the [CAST AI agent](https://github.com/castai/k8s-agent), you can start observing the running costs and potential savings of your cluster - and then enable the features that optimize your cluster - like adding and removing nodes or rightsizing deployments.
 
-To get started, login to the console and navigate to **Connect cluster** window.
+To get started, log into the console and navigate to the **Connect cluster** window.
 
 ![img.png](../screenshots/connect-cluster.png)
 
-Script will install the agent that will run inside the cluster in read-only mode. After the installation, agent will collect and analyze your cluster configuration to provide most optimal setup along with savings estimation for your current cloud environment.
+The cript will install the agent that will run inside the cluster in read-only mode. After the installation, the agent will collect and analyze your cluster configuration to provide the most optimal setup along with a savings estimation for your current cloud environment.
 
-To start saving costs, turn on the automatic optimization when ready.
+To start saving costs, turn the automatic optimization on when you're ready.
 
 Connect your cluster:
 

--- a/docs/getting-started/external-cluster/overview.md
+++ b/docs/getting-started/external-cluster/overview.md
@@ -4,16 +4,17 @@ description: Explore how external cluster management brings CAST AI features to 
 
 # External Cluster Overview
 
-External cluster management brings CAST AI features, like autoscaler, to an externally managed clusters, like EKS, GKE
-or AKS. By installing CAST AI agent, you start observing cluster running costs and potential savings; you can then
-enable features that optimize your cluster - like adding and removing nodes, or right-sizing deployments. To get started,
-login to the console and navigate to **Connect cluster** window.
+External cluster management brings CAST AI features, like autoscaler, to externally managed clusters EKS, GKE
+or AKS. By installing [CAST AI agent](https://github.com/castai/k8s-agent), you start observing cluster running costs and potential savings; you can then
+enable features that optimize your cluster - like adding and removing nodes, or right-sizing deployments.
+
+To get started, login to the console and navigate to **Connect cluster** window.
 
 ![img.png](../screenshots/connect-cluster.png)
 
-Script will install the agent that will run inside the cluster in read-only mode. After installation, agent will collect
-and analyze your cluster configuration to provide most optimal setup along with savings estimation for your current
-cloud environment. To start saving costs, turn on the automatic optimization when ready.
+Script will install the agent that will run inside the cluster in read-only mode. After the installation, agent will collect and analyze your cluster configuration to provide most optimal setup along with savings estimation for your current cloud environment.
+
+To start saving costs, turn on the automatic optimization when ready.
 
 Connect your cluster:
 

--- a/docs/guides/k8s-agent.md
+++ b/docs/guides/k8s-agent.md
@@ -4,7 +4,7 @@ description: Learn more about the CAST AI external agent and get help if you nee
 
 # External Cluster Agent
 
-* GitHub repository: <https://github.com/castai/k8s-agent>
+Public GitHub repository: <https://github.com/castai/k8s-agent>
 
 ![Agent Install script](agent/k8s-agent_connect.png)
 
@@ -12,7 +12,9 @@ description: Learn more about the CAST AI external agent and get help if you nee
 
 ---
 
-### Your cluster does not appear in the Console Dashboard
+### Your cluster does not appear in the Connect Cluster screen
+
+If a cluster is not appearing in the Connect your cluster screen after you've run the connection script, perform following steps.
 
 1. Check the Pod logs:
 
@@ -22,62 +24,82 @@ description: Learn more about the CAST AI external agent and get help if you nee
 
 2. You might get output similar to this:
 
-   ```text
-   time="2021-05-06T14:24:03Z" level=info msg="starting the agent"
-   time="2021-05-06T14:24:03Z" level=info msg="using cluster provider discovery"
-   time="2021-05-06T14:24:03Z" level=fatal msg="agent failed: registering cluster: getting cluster name: describing instance_id=i-026b5fadab5b69d67: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: 2165c357-b4a6-4f30-9266-a51f4aaa7ce7"
-   ```
+    ```text
+    time="2021-05-06T14:24:03Z" level=info msg="starting the agent"
+    time="2021-05-06T14:24:03Z" level=info msg="using cluster provider discovery"
+    time="2021-05-06T14:24:03Z" level=fatal msg="agent failed: registering cluster: getting cluster name: describing instance_id=i-026b5fadab5b69d67: UnauthorizedOperation: You are not authorized to perform this operation.\n\tstatus code: 403, request id: 2165c357-b4a6-4f30-9266-a51f4aaa7ce7"
+    ```
 
-    * This particular example indicates that we failed to collect the relevant data required to identify your cluster on our system.
+This particular example indicates that we failed to collect the relevant data required to identify your cluster on our system.
 
-3. To solve this issue, create a deployment file such as this:
+To solve this issue:
 
-   ```yaml
-   apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: castai-agent
-     namespace: castai-agent
-     labels:
-       "app.kubernetes.io/name": castai-agent
-   spec:
-     replicas: 1
-     selector:
-       matchLabels:
-         "app.kubernetes.io/name": castai-agent
-     template:
-       metadata:
-         labels:
-           "app.kubernetes.io/name": castai-agent
-       spec:
-         serviceAccountName: castai-agent
-         containers:
-           - name: agent
-             image: castai/agent:latest
-             env:
-               - name: API_URL
-                 value: api.cast.ai
-               - name: EKS_ACCOUNT_ID
-                 value: {YOUR-AWS-ACCOUNT-ID} # FILL THIS
-               - name: EKS_REGION
-                 value: {YOUR-EKS-CLUSTER-REGION} # FILL THIS
-               - name: EKS_CLUSTER_NAME
-                 value: {YOUR-CLUSTER-NAME} # FILL THIS
-             envFrom:
-               - secretRef:
-                   name: castai-agent
-             resources:
-               requests:
-                 cpu: 100m
-                 memory: 64Mi
-               limits:
-                 cpu: 1000m
-                 memory: 256Mi
-   ```
+1. Create a deployment file such as this:
 
-   * Add the values for the missing parts next to the `#FILL THIS` comment.
+    ```yaml
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: castai-agent
+      namespace: castai-agent
+      labels:
+        "app.kubernetes.io/name": castai-agent
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          "app.kubernetes.io/name": castai-agent
+      template:
+        metadata:
+          labels:
+            "app.kubernetes.io/name": castai-agent
+        spec:
+          serviceAccountName: castai-agent
+          containers:
+            - name: agent
+              image: castai/agent:latest
+              env:
+                - name: API_URL
+                  value: api.cast.ai
+                - name: EKS_ACCOUNT_ID
+                  value: {YOUR-AWS-ACCOUNT-ID} # FILL THIS
+                - name: EKS_REGION
+                  value: {YOUR-EKS-CLUSTER-REGION} # FILL THIS
+                - name: EKS_CLUSTER_NAME
+                  value: {YOUR-CLUSTER-NAME} # FILL THIS
+              envFrom:
+                - secretRef:
+                    name: castai-agent
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 64Mi
+                limits:
+                  cpu: 1000m
+                  memory: 256Mi
+    ```
 
-   * Apply the deployment file using `kubectl apply -f deployment.yaml`.
+2. Add the values for the missing parts next to the `#FILL THIS` comment.
+
+3. Apply the deployment file using `kubectl apply -f deployment.yaml`.
+
+### Out-dated CAST AI agent version
+
+To check which agent version is running on your cluster run the following command:
+
+  ```sh
+  kubectl describe pod castai-agent -n castai-agent | grep castai/agent:v
+  ```
+
+You can cross-check our [Github repository](https://github.com/castai/k8s-agent) for a number of the latest version available.
+
+In order to upgrade CAST AI agent version please perform following steps:
+
+1. Go to [Connect cluster](https://console.dev-master.cast.ai/external-clusters/new)
+2. Select correct cloud service provider
+3. Run the provided script
+
+Latest version of CAST AI agent is now deployed in your cluster.
 
 !!! tip
       If you are still encountering any issues, ping us with logs output at:

--- a/docs/guides/k8s-agent.md
+++ b/docs/guides/k8s-agent.md
@@ -56,27 +56,36 @@ To solve this issue:
         spec:
           serviceAccountName: castai-agent
           containers:
+            - name: autoscaler
+              image: k8s.gcr.io/cpvpa-amd64:v0.8.3
+              command:
+                - /cpvpa
+                - --target=deployment/castai-agent
+                - --namespace=castai-agent
+                - --poll-period-seconds=300
+                - --config-file=/etc/config/castai-agent-autoscaler
+              volumeMounts:
+                - mountPath: /etc/config
+                  name: castai-agent-autoscaler
             - name: agent
-              image: castai/agent:latest
+              image: "castai/agent:v0.19.2"
               env:
                 - name: API_URL
                   value: api.cast.ai
-                - name: EKS_ACCOUNT_ID
-                  value: {YOUR-AWS-ACCOUNT-ID} # FILL THIS
-                - name: EKS_REGION
-                  value: {YOUR-EKS-CLUSTER-REGION} # FILL THIS
-                - name: EKS_CLUSTER_NAME
-                  value: {YOUR-CLUSTER-NAME} # FILL THIS
+                - name: PROVIDER
+                  value: "eks"
               envFrom:
                 - secretRef:
                     name: castai-agent
               resources:
                 requests:
                   cpu: 100m
-                  memory: 64Mi
                 limits:
                   cpu: 1000m
-                  memory: 256Mi
+          volumes:
+            - name: castai-agent-autoscaler
+              configMap:
+                name: castai-agent-autoscaler
     ```
 
 2. Add the values for the missing parts next to the `#FILL THIS` comment.

--- a/docs/guides/k8s-agent.md
+++ b/docs/guides/k8s-agent.md
@@ -95,7 +95,7 @@ You can cross-check our [Github repository](https://github.com/castai/k8s-agent)
 
 In order to upgrade CAST AI agent version please perform following steps:
 
-1. Go to [Connect cluster](https://console.dev-master.cast.ai/external-clusters/new)
+1. Go to [Connect cluster](https://console.cast.ai/external-clusters/new)
 2. Select correct cloud service provider
 3. Run the provided script
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,14 @@ It is one platform that cuts your cloud costs, boosts DevOps, and prevents downt
 
 ## Easy to start
 
-Deploy your first cluster in 5-10 minutes. Follow our [getting started](./getting-started/overview.md) guide to try it out!
+First connect your cluster to CAST AI and see how much you can save by optimizing cluster configuration. After exploring the savings you can onboard the cluster into CAST AI and turn on cost optimization policies, they will manage your cluster for you. Follow [the guide to learn more](./getting-started/external-cluster/overview.md).
 
-Or [connect your cluster](./getting-started/external-cluster/overview.md) with read-only mode and we will calculate and provide you estimated monthly savings.
+Alternatively, you can also deploy new cluster from scratch and benefit from true multicloud setup. Follow our [getting started](./getting-started/overview.md) guide to try it out!
+
+It takes less than 5 minutes to fully onboard external cluster and less than 10 minutes to setup a new multicloud cluster in CAST AI. CAST AI abstracts layers of technical complexity from the user, so there is little knowledge required to use the product:
+
+- basics of running Kubernetes cluster in the public cloud (AWS, GCP, AKS)
+- working knowledge of `kubectl`command line utility for creating and managing Kubernetes clusters
 
 ## Community
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ First connect your cluster to CAST AI and see how much you can save by optimizin
 
 Alternatively, you can also deploy new cluster from scratch and benefit from true multicloud setup. Follow our [getting started](./getting-started/overview.md) guide to try it out!
 
-It takes less than 5 minutes to fully onboard external cluster and less than 10 minutes to setup a new multicloud cluster in CAST AI. CAST AI abstracts layers of technical complexity from the user, so there is little knowledge required to use the product:
+It takes less than 5 minutes to fully onboard an external cluster and less than 10 minutes to setup a new multicloud cluster in CAST AI. CAST AI abstracts layers of technical complexity from the user, so there is little knowledge required to use the product:
 
 - basics of running Kubernetes cluster in the public cloud (AWS, GCP, AKS)
 - working knowledge of `kubectl` command line utility for creating and managing Kubernetes clusters

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Alternatively, you can also deploy new cluster from scratch and benefit from tru
 It takes less than 5 minutes to fully onboard external cluster and less than 10 minutes to setup a new multicloud cluster in CAST AI. CAST AI abstracts layers of technical complexity from the user, so there is little knowledge required to use the product:
 
 - basics of running Kubernetes cluster in the public cloud (AWS, GCP, AKS)
-- working knowledge of `kubectl`command line utility for creating and managing Kubernetes clusters
+- working knowledge of `kubectl` command line utility for creating and managing Kubernetes clusters
 
 ## Community
 


### PR DESCRIPTION
Updates to docs to meed Amazon Partnership Network requirements:
Added expected time to connect external cluster and required skills to use CAST
Added troubleshooting scenario for "outdated" castai agent