### PR TITLE
Add docs for the scheduling.cast.ai/storage-optimized label

### DIFF
--- a/docs/guides/autoscaling-policies.md
+++ b/docs/guides/autoscaling-policies.md
@@ -91,6 +91,10 @@ Using the *interruption tolerance* setting, you can restrict which instances typ
 
 By using this feature, you can guarantee that workloads designated for spot instances have capacity to run even if spot inventory is temporarily not available. To mitigate the impact of spot drought, CAST AI provisions *fallback* node (i.e. a temporary on-demand node) and use it to schedule the impacted workloads. Once the configured time expires, CAST AI will automatically attempt to find the suitable spot node. If it is available, it will get provisioned - then the *fallback* node will be drained and deleted. As a result, the impacted workloads will get scheduled on the spot node in the same way as prior to the spot drought event.
 
+## Storage Optimized Instances policy
+
+This policy instructs the CAST AI engine to purchase Storage Optimized instances and place specifically labelled pods on those instances. CAST AI automatically handles instance interruptions and replaces instances when they are terminated by the CSP. You can find a detailed guide on how to configure your workloads to run on Storage Optimized instances [here](../guides/storage-optimized.md).
+
 ## Unscheduled pods policy
 
 A pod becomes unschedulable when the Kubernetes scheduler cannot find a node to which it can assign the pod.

--- a/docs/guides/storage-optimized.md
+++ b/docs/guides/storage-optimized.md
@@ -1,0 +1,37 @@
+---
+description: CAST AI supports running your workloads on Storage Optimized instances. This guide helps you configure and run it.
+---
+
+# Storage Optimized Instances
+
+The CAST AI autoscaler supports running your workloads on Storage Optimized instances.
+This guide will help you configure and run it.
+
+## Available configurations
+
+### Tolerations
+
+**When to use:** Storage Optimized instances are optional
+
+When a pod is marked only with `tolerations,` the Kubernetes scheduler could place such a pod/pods on regular nodes as well.
+
+```yaml
+tolerations:
+  - key: scheduling.cast.ai/storage-optimized
+    operator: Exists
+```
+
+### Node Selectors
+
+**When to use:** only use Storage Optimized instances
+
+If you want to make sure that a pod is scheduled on Storage Optimized instances only, add `nodeSelector` as well as per the example below.
+The autoscaler will then ensure that only a Storage Optimized instance is picked whenever your pod requires additional workload in the cluster.
+
+```yaml
+tolerations:
+  - key: scheduling.cast.ai/storage-optimized
+    operator: Exists
+nodeSelector:
+  scheduling.cast.ai/storage-optimized: "true"
+```

--- a/docs/guides/storage-optimized.md
+++ b/docs/guides/storage-optimized.md
@@ -4,10 +4,37 @@ description: CAST AI supports running your workloads on Storage Optimized instan
 
 # Storage Optimized Instances
 
+Storage optimized instances are specific instance types, designed for workloads that require high, sequential read and write access to very large data sets on local storage. They are optimized to deliver a huge amount of low-latency, random I/O operations per second (IOPS) to applications. This makes them a better choice for performance compared to other cloud services.
+
+There are multiple instances available in the supported providers (GCS and AWS so far) and they can provide network performance, SSD I/O performance, NVMe volumes, etc. For an extended specification and instructions about the instances available and their features, please refer to the following official documentation:
+
+Storage options
+
+- AWS: [Storage optimized instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/storage-optimized-instances.html)
+- GCS: [Local SSD disks](https://cloud.google.com/compute/docs/disks#localssds)
+
 The CAST AI autoscaler supports running your workloads on Storage Optimized instances.
-This guide will help you configure and run it.
+The following guide will help you configure and run it.
+
+## Pricing
+
+### GCS
+
+Because local SSDs can only be purchased in 375 GB increments, the cost-per-month for a single device is the monthly rate multiplied by 375 GB. For example, at a monthly rate of $0.080, the cost would be $30.00 per device per month. Actual data storage and usage are included in that price and there is no additional charge for local traffic between the virtual machine and the local SSD device. [Local SSD prices](https://cloud.google.com/compute/disks-image-pricing#localssdpricing) differ by region.
+
+You can reserve local SSDs in a specific zone, with or without a commitment. Without a commitment, you pay normal on-demand prices. For committed-use discounted pricing for local SSDs, a reservation must be created when purchasing the commitment. For more information, see [Reserving zonal resources](https://cloud.google.com/compute/docs/instances/reserving-zonal-resources).
+
+Spot prices apply to local SSDs attached to [Spot VMs](https://cloud.google.com/compute/docs/instances/spot) (or preemptible VMs). Spot prices provide smaller discounts for local SSDs than for machine types and GPUs. Local SSDs attached to Spot VMs are not eligible for other discounts.
+
+### AWS
+
+In the case of AWS, the price is associated with the type of instance and the type of plan chosen, which can be: On-Demand, Savings Plans, Reserved Instances, Spot Instances or Dedicated Hosts.
+
+Please refer to [official pricing source](https://aws.amazon.com/ec2/pricing/) to know more.
 
 ## Available configurations
+
+To make use of the storage-optimized feature, node selectors, taints and tolerations work together to ensure that pods are scheduled into inappropriate nodes and viceversa.
 
 ### Tolerations
 

--- a/docs/guides/storage-optimized.md
+++ b/docs/guides/storage-optimized.md
@@ -20,7 +20,7 @@ The following guide will help you configure and run it.
 
 ### GCS
 
-Because local SSDs can only be purchased in 375 GB increments, the cost-per-month for a single device is the monthly rate multiplied by 375 GB. For example, at a monthly rate of $0.080, the cost would be $30.00 per device per month. Actual data storage and usage are included in that price and there is no additional charge for local traffic between the virtual machine and the local SSD device. [Local SSD prices](https://cloud.google.com/compute/disks-image-pricing#localssdpricing) differ by region.
+Because local SSDs can only be purchased in 375 GB increments, the cost-per-month for a single device is the monthly rate multiplied by 375 GB. For example, at a monthly rate of $0.080/GB, the cost would be $30.00 per device per month. Actual data storage and usage are included in that price and there is no additional charge for local traffic between the virtual machine and the local SSD device. [Local SSD prices](https://cloud.google.com/compute/disks-image-pricing#localssdpricing) differ by region.
 
 You can reserve local SSDs in a specific zone, with or without a commitment. Without a commitment, you pay normal on-demand prices. For committed-use discounted pricing for local SSDs, a reservation must be created when purchasing the commitment. For more information, see [Reserving zonal resources](https://cloud.google.com/compute/docs/instances/reserving-zonal-resources).
 
@@ -36,19 +36,7 @@ Please refer to [official pricing source](https://aws.amazon.com/ec2/pricing/) t
 
 To make use of the storage-optimized feature, node selectors, taints and tolerations work together to ensure that pods are scheduled into inappropriate nodes and viceversa.
 
-### Tolerations
-
-**When to use:** Storage Optimized instances are optional
-
-When a pod is marked only with `tolerations,` the Kubernetes scheduler could place such a pod/pods on regular nodes as well.
-
-```yaml
-tolerations:
-  - key: scheduling.cast.ai/storage-optimized
-    operator: Exists
-```
-
-### Node Selectors
+### Node Selectors and tolerations
 
 **When to use:** only use Storage Optimized instances
 

--- a/docs/product-overview/console/autoscaler.md
+++ b/docs/product-overview/console/autoscaler.md
@@ -12,7 +12,7 @@ Users who have connected an external cluster to CAST AI have two options how to 
 
 ![](images/autoscaler-selection.png)
 
-  **Scoped autoscaler** - is a mode of operations where CAST AI autoscaler co-exists with other autoscaler(s) on the same cluster and is managing only specific workloads. In order to restrict the scope of the autoscaler, workloads have to be modified as prescribed in this [guide](/guides/autoscaling-policies/#scoped-autoscaler-mode).
+  **Scoped autoscaler** - is a mode of operations where CAST AI autoscaler co-exists with other autoscaler(s) on the same cluster and is managing only specific workloads. In order to restrict the scope of the autoscaler, workloads have to be modified as prescribed in this [guide](../../guides/autoscaling-policies.md#scoped-autoscaler-mode).
 
   Scoped autoscaler will not ensure that all workloads on the cluster have capacity to run and advanced features like Rebalancer are not available in this mode. Due to these limitations we recommend using CAST AI autoscaler as the only autoscaler on the cluster (i.e. in the full autscaling mode).
 

--- a/docs/product-overview/console/autoscaler.md
+++ b/docs/product-overview/console/autoscaler.md
@@ -46,3 +46,4 @@ For more information see:
 - [Autoscaling policies](../../guides/autoscaling-policies.md)
 - [Horizontal Pod autoscaler](../../guides/hpa.md)
 - [Spot/Preemptible Instances](../../guides/spot.md)
+- [Storage Optimized Instances](../../guides/storage-optimized.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - 'Start saving quickly': guides/start-saving-quickly.md
       - guides/hpa.md
       - guides/spot.md
+      - guides/storage-optimized.md
       - guides/vpa.md
       - 'Node kernel tuning': guides/node-kernel-tuning.md
       - guides/evictor.md


### PR DESCRIPTION
Adds a new reference page that describes how to configure node affinity for storage-optimized pod/pods, nodes and instances.